### PR TITLE
Update docker to use ES6 compatible node 4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12
+FROM node:4.2
 MAINTAINER tribou
 
 # Prepare app directory


### PR DESCRIPTION
Docker build failed due to node 0.12 in Dockerfile
